### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   # Zabbix MySQL Database
   zabbix-db:
-    image: mysql:latest
+    image: mysql:9.0
     container_name: zabbix-db
     command: --character-set-server=utf8mb4 --collation-server=utf8mb4_bin --log-bin-trust-function-creators=1
     environment:


### PR DESCRIPTION
The Zabbix Docker Compose setup is compatible with MySQL version 9.0.x or earlier. Therefore, I have updated the MySQL image from "latest" to version 9.0.